### PR TITLE
New updated baseline travisci config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: go
 sudo: false
-services:
-  - mysql
 go:
-  - 1.8
+  - 1.9
 before_install:
-  - go get github.com/mattn/goveralls
+  - go get -t ./...
 script:
-  - $HOME/gopath/bin/goveralls -service=travis-ci -ignore=main.go
+  - make tag
+before_deploy:
+  - docker login -u ${DOCKER_USER} -p ${DOCKER_PASSWORD}
+deploy:
+  provider: script
+  script: make publish
+  on:
+    branch: master


### PR DESCRIPTION
New baseline TravisCI config that builds on every commit but only publishes containers to Docker Hub from master.